### PR TITLE
remove .travis.yml pip install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,9 @@
 before_install: sudo apt-get install libicu-dev libmagic-dev -y
 language: python
 python:
-#  - "2.5"
   - "2.6"
   - "2.7"
-#  - "3.2"
-#  - "3.3"
 # command to install dependencies
-# install:
-#  - "pip install charlockholmes"
 branches:
   only:
     - master


### PR DESCRIPTION
跑 CI 的 install 是安装当前仓库需要的依赖。
